### PR TITLE
New file gives explicit typings to PNG files

### DIFF
--- a/typings/custom.d.ts
+++ b/typings/custom.d.ts
@@ -1,0 +1,4 @@
+declare module "*.png" {
+  const content: any;
+  export default content;
+}


### PR DESCRIPTION
Currently (or at least, on my rather heavily modified fork) importing image files directly into pages fails because typescript doesn't understand what a png file is.

According to the webpack/typescript docs, under "Importing other Assets", this can be solved by adding an explicit type: https://webpack.js.org/guides/typescript/

This submit was all that was required to re-enable image loading for my project
eg

    import ImgLogo from "./logo.png"
    ...
    <img src={ImgLogo} />

Side note: I haven't tested this on the raw react-bp-ts project