### PR TITLE
Fixed regression causing throw unloading sagas

### DIFF
--- a/app/utils/sagaInjectors.ts
+++ b/app/utils/sagaInjectors.ts
@@ -72,7 +72,7 @@ export function ejectSagaFactory(store: LifeStore, isValid: boolean) {
 
     if (Reflect.has(store.injectedSagas, key)) {
       const descriptor = store.injectedSagas[key];
-      if (descriptor.mode !== DAEMON) {
+      if (descriptor.mode && descriptor.mode !== DAEMON) {
         descriptor.task.cancel();
         // Clean up in production; in development we need `descriptor.saga` for hot reloading
         if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
The original RBP tested descriptor for existence before attempting to cancel it.

In this TS version that check is not there (I assume removed in the conversion to TS?)

In production builds of this website my saga's throw when unloading.  I don't know whether they are unloading twice or why this is happening but this change is consistent with original code and fixes the issue

## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [ ] Double-check your branch is based on `dev` and targets `dev` 
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/react-boilerplate/react-boilerplate/blob/master/LICENSE.md).
