### PR TITLE
Fixed setup and clean commands

### DIFF
--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -14,11 +14,12 @@ if (!shell.test('-e', 'internals/templates')) {
 process.stdout.write('Cleanup started...');
 
 // Reuse existing LanguageProvider and i18n tests
-shell.mv(
-  'app/containers/LanguageProvider/tests',
-  'internals/templates/containers/LanguageProvider',
-);
-shell.cp('app/tests/i18n.test.js', 'internals/templates/tests/i18n.test.js');
+// FIXME: fix the tests
+// shell.mv(
+//   'app/containers/LanguageProvider/tests',
+//   'internals/templates/containers/LanguageProvider',
+// );
+// shell.cp('app/tests/i18n.test.js', 'internals/templates/tests/i18n.test.js');
 
 // Cleanup components/
 shell.rm('-rf', 'app/components/*');
@@ -28,7 +29,8 @@ shell.rm('-rf', 'app/containers');
 shell.mv('internals/templates/containers', 'app');
 
 // Handle tests/
-shell.mv('internals/templates/tests', 'app');
+// FIXME: fix the tests
+// shell.mv('internals/templates/tests', 'app');
 
 // Handle translations/
 shell.rm('-rf', 'app/translations');

--- a/internals/scripts/setup.js
+++ b/internals/scripts/setup.js
@@ -34,11 +34,7 @@ cleanRepo(() => {
 function cleanRepo(callback) {
   fs.readFile('.git/config', 'utf8', (err, data) => {
     if (!err) {
-      const isClonedRepo =
-        typeof data === 'string' &&
-        (data.match(/url\s*=/g) || []).length === 1 &&
-        /react-boilerplate\/react-boilerplate\.git/.test(data);
-      if (isClonedRepo) {
+      if (isClonedRepo(data)) {
         process.stdout.write('\nDo you want to clear old repository? [Y/n] ');
         process.stdin.resume();
         process.stdin.on('data', pData => {
@@ -58,6 +54,17 @@ function cleanRepo(callback) {
       callback();
     }
   });
+}
+
+function isClonedRepo(gitConfig) {
+  if (typeof gitConfig !== 'string')
+    return false;
+
+  // Validate there is only one URL clause in the configuration
+  if ((gitConfig.match(/url\s*=/g) || []).length !== 1)
+    return false;
+
+  return /\/react-boilerplate-typescript\b/.test(gitConfig);
 }
 
 /**


### PR DESCRIPTION
Quick fixes to the following commands:

- `npm run setup` - Fixed clone source detection. It was hard-coded to the original repository name.
- `npm run clean` - Don't try to copy the nonexistent test directories.

Both issues happened because of the changes introduced after the fork from `react-boilerplate`.