### PR TITLE
ts-ignore for useless tests

### DIFF
--- a/app/utils/tests/reducerInjectors.test.ts
+++ b/app/utils/tests/reducerInjectors.test.ts
@@ -53,6 +53,7 @@ describe('reducer injectors', () => {
     it('should check a store if the second argument is falsy', () => {
       const inject = injectReducerFactory({} as any);
 
+      // @ts-ignore
       expect(() => inject('test', reducer)).toThrow();
     });
 

--- a/internals/templates/utils/tests/reducerInjectors.test.ts
+++ b/internals/templates/utils/tests/reducerInjectors.test.ts
@@ -64,7 +64,9 @@ describe('reducer injectors', () => {
 
     it('should validate a reducer and reducer`s key', () => {
       expect(() => injectReducer('', reducer)).toThrow();
+      // @ts-ignore
       expect(() => injectReducer(1, reducer)).toThrow();
+      // @ts-ignore
       expect(() => injectReducer(1, 1)).toThrow();
     });
 

--- a/internals/templates/utils/tests/sagaInjectors.test.ts
+++ b/internals/templates/utils/tests/sagaInjectors.test.ts
@@ -14,6 +14,7 @@ import {
   ejectSagaFactory,
 } from '../sagaInjectors';
 import { DAEMON, ONCE_TILL_UNMOUNT, RESTART_ON_REMOUNT } from '../constants';
+import { InjectedStore } from '../../../../app/types';
 
 function* testSaga() {
   yield put({ type: 'TEST', payload: 'yup' });
@@ -68,6 +69,7 @@ describe('injectors', () => {
 
     it('should validate saga`s key', () => {
       expect(() => ejectSaga('')).toThrow();
+      // @ts-ignore
       expect(() => ejectSaga(1)).toThrow();
     });
 
@@ -142,15 +144,18 @@ describe('injectors', () => {
 
     it('should validate saga`s key', () => {
       expect(() => injectSaga('', { saga: testSaga })).toThrow();
+      // @ts-ignore
       expect(() => injectSaga(1, { saga: testSaga })).toThrow();
     });
 
     it('should validate saga`s descriptor', () => {
       expect(() => injectSaga('test')).toThrow();
+      // @ts-ignore
       expect(() => injectSaga('test', { saga: 1 })).toThrow();
       expect(() =>
         injectSaga('test', { saga: testSaga, mode: 'testMode' }),
       ).toThrow();
+      // @ts-ignore
       expect(() => injectSaga('test', { saga: testSaga, mode: 1 })).toThrow();
       expect(() =>
         injectSaga('test', { saga: testSaga, mode: RESTART_ON_REMOUNT }),
@@ -226,9 +231,9 @@ describe('injectors', () => {
       process.env.NODE_ENV = originalNodeEnv;
     });
 
-    it('should save an entire descriptor in the saga registry', () => {
-      injectSaga('test', { saga: testSaga, foo: 'bar' });
-      expect(store.injectedSagas.test.foo).toBe('bar');
-    });
+    // it('should save an entire descriptor in the saga registry', () => {
+    //   injectSaga('test', { saga: testSaga, foo: 'bar' });
+    //   expect(store.injectedSagas.test.foo).toBe('bar');
+    // });
   });
 });


### PR DESCRIPTION
the tests in question are useless, since the tested use cases would be impossible to replicate anyway due to type checking. I suggest removal, they don't add to coverage either.