### PR TITLE
add redux-devtools-extension to get rid of boilerplate types and any

### DIFF
--- a/app/tests/store.test.ts
+++ b/app/tests/store.test.ts
@@ -2,9 +2,9 @@
  * Test store addons
  */
 import history from '../utils/history';
-
 import configureStore from '../configureStore';
 import { InjectedStore } from '../types';
+import { composeWithDevTools } from 'redux-devtools-extension';
 
 describe('configureStore', () => {
   let store: InjectedStore;
@@ -32,11 +32,14 @@ describe('configureStore', () => {
   });
 });
 
+
+jest.mock('redux-devtools-extension', () => ({
+  composeWithDevTools: jest.fn(),
+}));
+
 describe('configureStore params', () => {
-  it('should call window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__', () => {
-    const compose = jest.fn();
-    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = () => compose;
+  it('should call composeWithDevTools', () => {
     configureStore(undefined, history);
-    expect(compose).toHaveBeenCalled();
+    expect(composeWithDevTools).toHaveBeenCalled();
   });
 });

--- a/internals/templates/tests/store.test.ts
+++ b/internals/templates/tests/store.test.ts
@@ -2,10 +2,10 @@
  * Test store addons
  */
 
-// import { BrowserRouter } from 'react-router-dom';
 import configureStore from '../configureStore';
 import history from '../utils/history';
 import { InjectedStore } from '../../../app/types';
+import { composeWithDevTools } from 'redux-devtools-extension';
 
 describe('configureStore', () => {
   let store: InjectedStore;
@@ -33,11 +33,13 @@ describe('configureStore', () => {
   });
 });
 
+jest.mock('redux-devtools-extension', () => ({
+  composeWithDevTools: jest.fn(),
+}));
+
 describe('configureStore params', () => {
-  it('should call window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__', () => {
-    const compose = jest.fn();
-    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = () => compose;
+  it('should call composeWithDevTools', () => {
     configureStore(undefined, history);
-    expect(compose).toHaveBeenCalled();
+    expect(composeWithDevTools).toHaveBeenCalled();
   });
 });

--- a/package.json
+++ b/package.json
@@ -71,9 +71,6 @@
     "babel-core": "7.0.0-bridge.0"
   },
   "dependencies": {
-    "@types/history": "^4.7.3",
-    "@types/react-router-dom": "^5.1.0",
-    "@types/react-test-renderer": "^16.9.0",
     "chalk": "2.4.2",
     "compression": "1.7.4",
     "connected-react-router": "6.5.0",
@@ -101,6 +98,10 @@
     "typesafe-actions": "4.4.0"
   },
   "devDependencies": {
+    "redux-devtools-extension": "^2.13.8",
+    "@types/history": "^4.7.3",
+    "@types/react-router-dom": "^5.1.0",
+    "@types/react-test-renderer": "^16.9.0",
     "@babel/cli": "7.5.0",
     "@babel/core": "7.5.4",
     "@babel/plugin-proposal-class-properties": "7.5.0",


### PR DESCRIPTION
one may argue "why add unnecessary deps", but it's in dev dependencies so irrelevant, and it removes extraneous interface and any type both in module and test.
also moved some types to dev deps.
passes all tests