### PR TITLE
remove incorrect unused CSS property

### DIFF
--- a/app/components/ReposList/tests/__snapshots__/index.test.tsx.snap
+++ b/app/components/ReposList/tests/__snapshots__/index.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`<ReposList /> should render the repositories if loading was successful 
         class="sc-htpNat cdjzok"
       >
         <div
-          class="sc-dnqmqq hIJpCG"
+          class="sc-dnqmqq gFbgzX"
         >
           <a
             class="sc-bZQynM sc-htoDjs zeaOm"

--- a/app/containers/RepoListItem/Wrapper.ts
+++ b/app/containers/RepoListItem/Wrapper.ts
@@ -4,7 +4,6 @@ const Wrapper = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
-  align-items: space-between;
 `;
 
 export default Wrapper;

--- a/app/containers/RepoListItem/tests/__snapshots__/index.test.tsx.snap
+++ b/app/containers/RepoListItem/tests/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<RepoListItem /> should render a ListItem 1`] = `
     class="sc-bdVaJa dTbRce"
   >
     <div
-      class="sc-bZQynM gZdeyD"
+      class="sc-bZQynM itBSjX"
     >
       <a
         class="sc-bxivhb sc-EHOje zeTZr"


### PR DESCRIPTION
`align-items: space-between` doesn't seem to do anything here, updated snapshot
fixes #40 
I can just change it to random valid value if changing snapshots is undesirable; it doesn't do anything regardless.