### PR TITLE
Fixing linting issues for generated containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: node_js
 
 node_js:
-  - 'node'
-  - 'lts/*'
+  - "node"
+  - "lts/*"
 
 services:
   - xvfb
 
 script:
   - node ./internals/scripts/generate-templates-for-linting
-  - git checkout -- .
   - npm test -- --maxWorkers=4
   - npm run build
 
@@ -21,7 +20,7 @@ notifications:
   email:
     on_failure: change
 
-after_success: 'npm run coveralls'
+after_success: "npm run coveralls"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 
 script:
   - node ./internals/scripts/generate-templates-for-linting
+  - git checkout -- .
   - npm test -- --maxWorkers=4
   - npm run build
 

--- a/app/components/Button/tests/index.test.tsx
+++ b/app/components/Button/tests/index.test.tsx
@@ -12,7 +12,6 @@ const href = 'http://mxstbr.com';
 const children = <h1>Test</h1>;
 const renderComponent = (props: Props & { type?: any } = {}) => {
   const utils = render(
-    // tslint:disable-next-line: jsx-wrap-multiline
     <Button href={href} {...props}>
       {children}
     </Button>,

--- a/app/components/Footer/tests/index.test.tsx
+++ b/app/components/Footer/tests/index.test.tsx
@@ -17,7 +17,6 @@ describe('<Footer />', () => {
   it('should render and match the snapshot', () => {
     const renderedComponent = renderer
       .create(
-        // tslint:disable-next-line: jsx-wrap-multiline
         <Provider store={store}>
           <IntlProvider locale="en">
             <Footer />

--- a/app/components/Header/tests/index.test.tsx
+++ b/app/components/Header/tests/index.test.tsx
@@ -14,7 +14,6 @@ describe('<Header />', () => {
 
   it('should render a div', () => {
     const { container } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <IntlProvider locale="en">
           <ConnectedRouter history={history}>

--- a/app/components/ReposList/tests/index.test.tsx
+++ b/app/components/ReposList/tests/index.test.tsx
@@ -16,7 +16,6 @@ describe('<ReposList />', () => {
 
   it('should render an error if loading failed', () => {
     const { queryByText } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <ReposList loading={false} error={{ message: 'Loading failed!' }} />
       </IntlProvider>,
@@ -52,7 +51,6 @@ describe('<ReposList />', () => {
       },
     ] as Repo[];
     const { container } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <IntlProvider locale="en">
           <ReposList repos={repos} error={false} loading={false}/>

--- a/app/components/Toggle/tests/index.test.tsx
+++ b/app/components/Toggle/tests/index.test.tsx
@@ -19,7 +19,6 @@ describe('<Toggle />', () => {
       },
     });
     const { container } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <Toggle values={['en', 'de']} messages={messages} />
       </IntlProvider>,

--- a/app/components/ToggleOption/tests/index.test.tsx
+++ b/app/components/ToggleOption/tests/index.test.tsx
@@ -14,7 +14,6 @@ describe('<ToggleOption />', () => {
       },
     });
     const { container } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <ToggleOption value="en" message={message.enMessage} />
       </IntlProvider>,
@@ -24,7 +23,6 @@ describe('<ToggleOption />', () => {
 
   it('should display `value`(two letter language code) when `message` is absent', () => {
     const { queryByText } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="de">
         <ToggleOption value="de" />
       </IntlProvider>,

--- a/app/containers/FeaturePage/tests/index.test.tsx
+++ b/app/containers/FeaturePage/tests/index.test.tsx
@@ -9,7 +9,6 @@ describe('<FeaturePage />', () => {
     const {
       container: { firstChild },
     } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <FeaturePage />
       </IntlProvider>,

--- a/app/containers/HomePage/tests/index.test.tsx
+++ b/app/containers/HomePage/tests/index.test.tsx
@@ -18,7 +18,6 @@ jest.mock('containers/App/actions');
 
 const renderHomePage = store =>
   render(
-    // tslint:disable-next-line: jsx-wrap-multiline
     <Provider store={store}>
       <IntlProvider locale="en">
         <HomePage />

--- a/app/containers/LanguageProvider/tests/index.test.tsx
+++ b/app/containers/LanguageProvider/tests/index.test.tsx
@@ -28,7 +28,6 @@ describe('<LanguageProvider />', () => {
     const text = 'Test';
     const children = <h1>{text}</h1>;
     const { queryByText } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <LanguageProvider messages={messages}>
           {children}
@@ -40,7 +39,6 @@ describe('<LanguageProvider />', () => {
 
   it('should render the default language messages', () => {
     const { queryByText } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <FormattedMessage {...messages.someMessage} />

--- a/app/containers/LocaleToggle/tests/index.test.tsx
+++ b/app/containers/LocaleToggle/tests/index.test.tsx
@@ -27,7 +27,6 @@ describe('<LocaleToggle />', () => {
 
   it('should match the snapshot', () => {
     const { container } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <LocaleToggle />
@@ -39,7 +38,6 @@ describe('<LocaleToggle />', () => {
 
   it('should present the default `en` english language option', () => {
     const { queryByDisplayValue } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <LocaleToggle />
@@ -51,7 +49,6 @@ describe('<LocaleToggle />', () => {
 
   it('should dispatch changeLocale when user selects a new option', () => {
     const { container } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <LanguageProvider messages={translationMessages}>
           <LocaleToggle />

--- a/app/containers/NotFoundPage/tests/index.test.tsx
+++ b/app/containers/NotFoundPage/tests/index.test.tsx
@@ -12,7 +12,6 @@ import messages from '../messages';
 describe('<NotFound />', () => {
   it('should render the Page Not Found text', () => {
     const { queryByText } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <NotFound />
       </IntlProvider>,

--- a/app/containers/RepoListItem/tests/index.test.tsx
+++ b/app/containers/RepoListItem/tests/index.test.tsx
@@ -26,7 +26,6 @@ const renderComponent = (item, currentUser) => {
     initialState, history);
 
   return render(
-    // tslint:disable-next-line: jsx-wrap-multiline
     <Provider store={store}>
       <IntlProvider locale="en">
         <RepoListItem item={item} />

--- a/app/types/index.d.ts
+++ b/app/types/index.d.ts
@@ -3,7 +3,7 @@ import { RouterState } from 'connected-react-router';
 import { ContainerState as LanguageProviderState } from 'containers/LanguageProvider/types';
 import { ContainerState as AppState } from 'containers/App/types';
 import { ContainerState as HomeState } from 'containers/HomePage/types';
-// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating continers seamlessly
+// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating containers seamlessly
 
 export interface InjectedStore extends Store {
   injectedReducers: any;
@@ -31,7 +31,7 @@ export interface ApplicationRootState {
   readonly global: AppState;
   readonly language: LanguageProviderState;
   readonly home: HomeState;
-  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating continers seamlessly
+  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating containers seamlessly
 
   // for testing purposes
   readonly test: any;

--- a/app/types/index.d.ts
+++ b/app/types/index.d.ts
@@ -3,6 +3,7 @@ import { RouterState } from 'connected-react-router';
 import { ContainerState as LanguageProviderState } from 'containers/LanguageProvider/types';
 import { ContainerState as AppState } from 'containers/App/types';
 import { ContainerState as HomeState } from 'containers/HomePage/types';
+// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating continers seamlessly
 
 export interface InjectedStore extends Store {
   injectedReducers: any;
@@ -30,6 +31,8 @@ export interface ApplicationRootState {
   readonly global: AppState;
   readonly language: LanguageProviderState;
   readonly home: HomeState;
+  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating continers seamlessly
+
   // for testing purposes
   readonly test: any;
 }

--- a/app/utils/tests/injectReducer.test.tsx
+++ b/app/utils/tests/injectReducer.test.tsx
@@ -108,7 +108,6 @@ describe('useInjectReducer hook', () => {
 
   it('should inject a given reducer', () => {
     render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithReducer />
       </Provider>,

--- a/app/utils/tests/injectSaga.test.tsx
+++ b/app/utils/tests/injectSaga.test.tsx
@@ -54,7 +54,6 @@ describe('injectSaga decorator', () => {
   it('should inject given saga, mode, and props', () => {
     const props = { test: 'test' };
     renderer.create(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -71,7 +70,6 @@ describe('injectSaga decorator', () => {
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
     const renderedComponent = renderer.create(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -92,7 +90,6 @@ describe('injectSaga decorator', () => {
   it('should propagate props', () => {
     const props = { testProp: 'test' };
     const renderedComponent = renderer.create(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -136,7 +133,6 @@ describe('useInjectSaga hook', () => {
   it('should inject given saga and mode', () => {
     const props = { test: 'test' };
     render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -152,7 +148,6 @@ describe('useInjectSaga hook', () => {
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
     const { unmount } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,

--- a/internals/generators/container/appendApplicationRootState.hbs
+++ b/internals/generators/container/appendApplicationRootState.hbs
@@ -1,2 +1,2 @@
-  readonly {{ camelCase name }}: {{ properCase name }}State;
-  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating continers seamlessly
+readonly {{ camelCase name }}: {{ properCase name }}State;
+// [INSERT NEW REDUCER KEY ABOVE] < Needed for generating containers seamlessly

--- a/internals/generators/container/appendApplicationRootState.hbs
+++ b/internals/generators/container/appendApplicationRootState.hbs
@@ -1,0 +1,2 @@
+  readonly {{ camelCase name }}: {{ properCase name }}State;
+  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating continers seamlessly

--- a/internals/generators/container/importContainerState.hbs
+++ b/internals/generators/container/importContainerState.hbs
@@ -1,0 +1,2 @@
+import { ContainerState as {{ properCase name }}State } from 'containers/{{ properCase name }}/types';
+// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating continers seamlessly

--- a/internals/generators/container/importContainerState.hbs
+++ b/internals/generators/container/importContainerState.hbs
@@ -1,2 +1,2 @@
 import { ContainerState as {{ properCase name }}State } from 'containers/{{ properCase name }}/types';
-// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating continers seamlessly
+// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating containers seamlessly

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -67,7 +67,7 @@ module.exports = {
     },
   ],
   actions: data => {
-    // Generate index.js and index.test.js
+    // Generate index.ts and index.test.tsx
     const actions = [
       {
         type: 'add',
@@ -81,7 +81,7 @@ module.exports = {
     if (data.wantMessages) {
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/tests/index.test.ts',
+        path: '../../app/containers/{{properCase name}}/tests/index.test.tsx',
         templateFile: './container/test.tsx.hbs',
         abortOnFail: true,
       });
@@ -97,8 +97,8 @@ module.exports = {
       });
     }
 
-    // If they want actions and a reducer, generate actions.js, constants.js,
-    // reducer.js and the corresponding tests for actions and the reducer
+    // If they want actions and a reducer, generate actions.ts, constants.ts,
+    // reducer.ts and the corresponding tests for actions and the reducer
     if (data.wantActionsAndReducer) {
       // Actions
       actions.push({

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -184,6 +184,20 @@ module.exports = {
         templateFile: './container/types.d.hbs',
         abortOnFail: true,
       });
+      actions.push({
+        type: 'modify',
+        path: '../../app/types/index.d.ts',
+        pattern: new RegExp(/.*\/\/.*\[IMPORT NEW CONTAINERSTATE ABOVE\].+\n\n*/),
+        templateFile: './container/importContainerState.hbs',
+        abortOnFail: true,
+      });
+      actions.push({
+        type: 'modify',
+        path: '../../app/types/index.d.ts',
+        pattern: new RegExp(/.*\/\/.*\[INSERT NEW REDUCER KEY ABOVE\].+\n\n*/),
+        templateFile: './container/appendApplicationRootState.hbs',
+        abortOnFail: true,
+      });
     }
 
     actions.push({

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -187,14 +187,14 @@ module.exports = {
       actions.push({
         type: 'modify',
         path: '../../app/types/index.d.ts',
-        pattern: new RegExp(/.*\/\/.*\[IMPORT NEW CONTAINERSTATE ABOVE\].+\n\n*/),
+        pattern: new RegExp(/.*\/\/.*\[IMPORT NEW CONTAINERSTATE ABOVE\].+\n/),
         templateFile: './container/importContainerState.hbs',
         abortOnFail: true,
       });
       actions.push({
         type: 'modify',
         path: '../../app/types/index.d.ts',
-        pattern: new RegExp(/.*\/\/.*\[INSERT NEW REDUCER KEY ABOVE\].+\n\n*/),
+        pattern: new RegExp(/.*\/\/.*\[INSERT NEW REDUCER KEY ABOVE\].+\n/),
         templateFile: './container/appendApplicationRootState.hbs',
         abortOnFail: true,
       });

--- a/internals/generators/container/index.tsx.hbs
+++ b/internals/generators/container/index.tsx.hbs
@@ -45,7 +45,6 @@ interface Props {}
 
 function {{ properCase name }}(props: Props) {
   {{#if wantActionsAndReducer}}
-  // Warning: Add your key to RootState in types/index.d.ts file
   useInjectReducer({ key: '{{ camelCase name }}', reducer: reducer });
   {{/if}}
   {{#if wantSaga}}

--- a/internals/generators/container/test.tsx.hbs
+++ b/internals/generators/container/test.tsx.hbs
@@ -12,7 +12,7 @@ import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 {{/if}}
 import { Provider } from 'react-redux';
-import { browserHistory } from 'react-router-dom';
+import history from 'utils/history';
 
 import {{ properCase name }} from '../index';
 {{#if wantMessages}}
@@ -23,7 +23,7 @@ describe('<{{ properCase name }} />', () => {
   let store;
 
   beforeEach(() => {
-    store = configureStore({}, browserHistory);
+    store = configureStore({}, history);
   });
 
   it('Expect to not log errors in console', () => {

--- a/internals/templates/containers/HomePage/tests/index.test.tsx
+++ b/internals/templates/containers/HomePage/tests/index.test.tsx
@@ -13,7 +13,6 @@ describe('<HomePage />', () => {
     const {
       container: { firstChild },
     } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <HomePage />
       </IntlProvider>,

--- a/internals/templates/containers/NotFoundPage/tests/index.test.tsx
+++ b/internals/templates/containers/NotFoundPage/tests/index.test.tsx
@@ -12,7 +12,6 @@ describe('<NotFound />', () => {
     const {
       container: { firstChild },
     } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <IntlProvider locale="en">
         <NotFound />
       </IntlProvider>,

--- a/internals/templates/types/index.d.ts
+++ b/internals/templates/types/index.d.ts
@@ -1,12 +1,15 @@
 import { Reducer, Store } from 'redux';
 import { RouterState } from 'connected-react-router';
 import { ContainerState as LanguageProviderState } from 'containers/LanguageProvider/types';
-// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating continers seamlessly
+// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating containers seamlessly
 
 export interface InjectedStore extends Store {
   injectedReducers: any;
   injectedSagas: any;
-  runSaga(saga: (() => IterableIterator<any>) | undefined, args: any | undefined): any;
+  runSaga(
+    saga: (() => IterableIterator<any>) | undefined,
+    args: any | undefined,
+  ): any;
 }
 
 export interface InjectReducerParams {
@@ -24,7 +27,7 @@ export interface InjectSagaParams {
 export interface ApplicationRootState {
   readonly router: RouterState;
   readonly language: LanguageProviderState;
-  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating continers seamlessly
+  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating containers seamlessly
 
   // for testing purposes
   readonly test: any;

--- a/internals/templates/types/index.d.ts
+++ b/internals/templates/types/index.d.ts
@@ -1,6 +1,7 @@
 import { Reducer, Store } from 'redux';
 import { RouterState } from 'connected-react-router';
 import { ContainerState as LanguageProviderState } from 'containers/LanguageProvider/types';
+// [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating continers seamlessly
 
 export interface InjectedStore extends Store {
   injectedReducers: any;
@@ -23,6 +24,8 @@ export interface InjectSagaParams {
 export interface ApplicationRootState {
   readonly router: RouterState;
   readonly language: LanguageProviderState;
+  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating continers seamlessly
+
   // for testing purposes
   readonly test: any;
 }

--- a/internals/templates/utils/tests/injectReducer.test.tsx
+++ b/internals/templates/utils/tests/injectReducer.test.tsx
@@ -111,7 +111,6 @@ describe('useInjectReducer hook', () => {
 
   it('should inject a given reducer', () => {
     render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithReducer />
       </Provider>,

--- a/internals/templates/utils/tests/injectSaga.test.tsx
+++ b/internals/templates/utils/tests/injectSaga.test.tsx
@@ -54,7 +54,6 @@ describe('injectSaga decorator', () => {
   it('should inject given saga, mode, and props', () => {
     const props = { test: 'test' };
     renderer.create(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -71,7 +70,6 @@ describe('injectSaga decorator', () => {
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
     const renderedComponent = renderer.create(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -92,7 +90,6 @@ describe('injectSaga decorator', () => {
   it('should propagate props', () => {
     const props = { testProp: 'test' };
     const renderedComponent = renderer.create(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -135,7 +132,6 @@ describe('useInjectSaga hook', () => {
   it('should inject given saga and mode', () => {
     const props = { test: 'test' };
     render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,
@@ -151,7 +147,6 @@ describe('useInjectSaga hook', () => {
   it('should eject on unmount with a correct saga key', () => {
     const props = { test: 'test' };
     const { unmount } = render(
-      // tslint:disable-next-line: jsx-wrap-multiline
       <Provider store={store}>
         <ComponentWithSaga {...props} />
       </Provider>,

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -10,14 +10,12 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 module.exports = options => ({
   mode: options.mode,
   entry: options.entry,
-  output: Object.assign(
-    {
-      // Compile into js/build.js
-      path: path.resolve(process.cwd(), 'build'),
-      publicPath: '/',
-    },
-    options.output,
-  ), // Merge with env dependent settings
+  output: {
+    // Compile into js/build.js
+    path: path.resolve(process.cwd(), 'build'),
+    publicPath: '/',
+    ...options.output,
+  }, // Merge with env dependent settings
   optimization: options.optimization,
   module: {
     rules: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
-  testPathIgnorePatterns: ['RbGen*'],
   collectCoverageFrom: [
     'app/**/*.{js,jsx,ts,tsx}',
     '!app/**/*.test.{js,jsx,ts,tsx}',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
+  testPathIgnorePatterns: ['RbGen*'],
   collectCoverageFrom: [
     'app/**/*.{js,jsx,ts,tsx}',
     '!app/**/*.test.{js,jsx,ts,tsx}',

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,8 @@
     "no-implicit-dependencies": false,
     "no-submodule-imports": false,
     "no-empty": false,
-    "jsx-alignment": false
+    "jsx-alignment": false,
+    "jsx-wrap-multiline": false
   },
   "linterOptions": {
     "exclude": ["**/*.js"]


### PR DESCRIPTION
## Fixing linting issues for generated containers

### Problem
Generated Containers with reducers, sagas and/or tests, produce linting issues:
- Reducers' and Sagas' keys need to be manually imported to `types\index.d.ts`.
- Generated `tests/.index` uses the extension .ts instead of .tsx
-  `Jsx-wrap-multiline` rule produce false positives in `tests/.index.tsx`

### Changes
- Add special comments in `app/types/index.d.ts` for the plop #modify action to find.
- Add two actions in `internals/generators/container/index.js` to automate adding new reducers key to RootState.
- Remove previous warning comments from the existing files and templates.
- Change the  `internals/generators/container/index.js` to create `tests/index.test.tsx` instead of `tests/index.test.ts`.
- Change `internals/generators/container/test.tsx.hbs` to use 'utils/history' instead of `browserHistory`.
- Disable `Jsx-wrap-multiline` in tslint.json and remove redundant comments everywhere else.

### Result and limitations
Currently, generating either Components or Container using any set of options will pass tslint.
I can't say the same about Languages, and I still couldn't fix all issues with generate-templates-for-linting.js yet.
If you would like to help with that please let me know, I am willing to put the work but I am very inexperienced with the current setup and some guidance might speed things up.

Thanks for your patience.