### PR TITLE
Button/tests/index uses hash based navigation

### DIFF
--- a/app/components/Button/tests/index.test.tsx
+++ b/app/components/Button/tests/index.test.tsx
@@ -8,7 +8,7 @@ import { fireEvent, render } from '@testing-library/react';
 import Button, { Props } from '../index';
 
 const handleRoute = () => {};
-const href = 'http://mxstbr.com';
+const href = '#/mxstbr';
 const children = <h1>Test</h1>;
 const renderComponent = (props: Props & { type?: any } = {}) => {
   const utils = render(


### PR DESCRIPTION
jsDOM throws an error in the console during `npm run test`.

This is because jsDOM only supports hash based navigation at the moment.

Switching the test to use a hash based url preserves the spirit of the test while squelching the error.