### PR TITLE
.eslintrc.js node .js import resolver to fix webstorm eslint error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,6 +125,9 @@ module.exports = {
       '@typescript-eslint/parser': ['.ts', '.tsx'],
     },
     'import/resolver': {
+      node: {
+        extensions: ['.js'] // webstorm IDE cannot resolve the webpack.babel.prod.js module correctly without this
+      },
       webpack: {
         config: './internals/webpack/webpack.prod.babel.js',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -126,7 +126,7 @@ module.exports = {
     },
     'import/resolver': {
       node: {
-        extensions: ['.js'] // webstorm IDE cannot resolve the webpack.babel.prod.js module correctly without this
+        extensions: ['.js', '.ts', '.tsx', '.jsx'] // webstorm IDE cannot resolve the webpack.babel.prod.js module correctly without this
       },
       webpack: {
         config: './internals/webpack/webpack.prod.babel.js',


### PR DESCRIPTION
Wish I had a good answer for why this fixes the eslint error described [here](https://github.com/react-boilerplate/react-boilerplate-typescript/issues/67), but it does.